### PR TITLE
Bump govuk-eleventy-plugin from 6.2.0 to 6.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@11ty/eleventy": "^2.0.1",
-        "@x-govuk/govuk-eleventy-plugin": "^6.2.0"
+        "@x-govuk/govuk-eleventy-plugin": "^6.2.1"
       }
     },
     "node_modules/@11ty/dependency-tree": {
@@ -724,9 +724,9 @@
       "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q=="
     },
     "node_modules/@x-govuk/govuk-eleventy-plugin": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@x-govuk/govuk-eleventy-plugin/-/govuk-eleventy-plugin-6.2.0.tgz",
-      "integrity": "sha512-stEbSoeneKEp7eHmEyf3J2Tqievms6f1et4yYsYUuc83Ugzj2LpuWDwXBj3GXOJvgZH/V+i6GfWzugimEY2vww==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@x-govuk/govuk-eleventy-plugin/-/govuk-eleventy-plugin-6.2.1.tgz",
+      "integrity": "sha512-VoPeLdR8vNDhWULbG5hUBBEQuU1zigNeoRWTg3io3/wtBGRiXBe7dXDszYf+VSe6aaTyTArUhvLkZ5n4DkQJ1g==",
       "dependencies": {
         "@11ty/eleventy": "^2.0.0",
         "@11ty/eleventy-navigation": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@11ty/eleventy": "^2.0.1",
-    "@x-govuk/govuk-eleventy-plugin": "^6.2.0"
+    "@x-govuk/govuk-eleventy-plugin": "^6.2.1"
   },
   "private": true
 }


### PR DESCRIPTION
Should fix an issue with the URLs in the Atom feed.