### PR TITLE
Switch to ESM imports

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -1,7 +1,7 @@
-const govukEleventyPlugin = require('@x-govuk/govuk-eleventy-plugin')
-const rssPlugin = require("@11ty/eleventy-plugin-rss");
+import govukEleventyPlugin from '@x-govuk/govuk-eleventy-plugin'
+import rssPlugin from "@11ty/eleventy-plugin-rss"
 
-module.exports = function(eleventyConfig) {
+export default function(eleventyConfig) {
 
   eleventyConfig.addPlugin(rssPlugin);
 

--- a/package.json
+++ b/package.json
@@ -15,5 +15,6 @@
     "@11ty/eleventy": "^3.0.0",
     "@x-govuk/govuk-eleventy-plugin": "^6.7.0"
   },
-  "private": true
+  "private": true,
+  "type": "module"
 }


### PR DESCRIPTION
Updates to use ESM imports now that Eleventy v3 supports it.

(Thanks to @paulrobertlloyd for the idea in https://github.com/x-govuk/x-govuk.github.io/pull/151)