### PR TITLE
Update `themeColor` to use NHS blue

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -32,6 +32,7 @@ export default function(eleventyConfig) {
       shortcut: false,
       mask: false
     },
+    themeColor: '#005eb8',
     stylesheets: ['/assets/styles.css'],
     feedUrl: 'posts/feed.xml',
     url: process.env.GITHUB_ACTIONS && 'https://frankieroberto.github.io/nhsnotes/'


### PR DESCRIPTION
GOV.UK brand blue is a different shade from NHS blue, but GOV.UK is the default blue used for a site’s `themeColor` unless specified otherwise.