### PR TITLE
Remove GOV.UK crown from footer

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -18,6 +18,7 @@ export default function(eleventyConfig) {
       contentLicence: {
         text: "This is a personal blog. Views expressed are not necessarily those of the NHS."
       },
+      logo: false,
       meta: {
         items: [
           {


### PR DESCRIPTION
…assuming you want to remove it (and you probably should).